### PR TITLE
Properly read log_opts

### DIFF
--- a/src/syslogger.erl
+++ b/src/syslogger.erl
@@ -32,7 +32,8 @@ open(undefined, LogOpts, Facility) ->
     {ok, [Progname]} = init:get_argument(progname),
     open(filename:basename(Progname), LogOpts, Facility);
 open(Ident, LogOpts, Facility) ->
-    syslog_open([Ident,$\0], LogOpts, Facility).
+    MapLogOpts = maps:from_list(proplists:unfold(LogOpts)),
+    syslog_open([Ident,$\0], MapLogOpts, Facility).
 
 syslog_open(_Ident, _LogOpts, _Facility) ->
     not_loaded(?LINE).


### PR DESCRIPTION
```
c_src is trying to read them as a map, when they're passed as a list, so
it would never succeed to configure it correctly. We could either make
it read a list in c_src/, or turn it to a map in src/.
I chose the latter.
```