### PR TITLE
Updated readme with the config settings for syslog facility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Configuration
 The syslogger application can be used either by configuring the handlers through
 application variables, or by using the `logger:add_handler/2` API.
 
-For instance if you want to add two handlers that log to two different syslog
+For instance if you want to add an handler that log to local0 syslog
 facilities just add this to your sys.config.
 
     {syslogger, [
@@ -55,7 +55,7 @@ facilities just add this to your sys.config.
       	}}]}]
     }.	
 
-This will add two syslogger instances to the Erlang l
+This will add a syslogger instances to the Erlang l
 
 Each syslogger handler can be configured using a map with these configuration options:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 syslogger
 =====
 
-A syslog backend for erlang logger.
+A syslog backend for erlang logger.. This is a fork of the syslogger with update to the application configuration settings
 
 Usage
 -----
@@ -11,7 +11,7 @@ in your rebar.config like this:
 
     {deps,
      [
-      { 'syslogger', "*", {git, "git://github.com/garazdawi/syslogger", {branch, "master"}}}
+      { 'syslogger', "*", {git, "https://github.com/sadekoya/syslogger.git", {branch, "master"}}}
      ]
     }.
 
@@ -46,20 +46,16 @@ application variables, or by using the `logger:add_handler/2` API.
 For instance if you want to add two handlers that log to two different syslog
 facilities just add this to your sys.config.
 
-    {syslogger,
-      {ident, "myapp"},
-      {log_opts, [cons, pid, perror]},
-      {logger, [{handler, user_syslogger, syslogger, #{ facility => user }},
-                {handler, local0_syslogger, syslogger, #{ facility => local0 }}]
-       }
-    }.
+    {syslogger, [
+  	{logger, [
+      	  {handler, local0_syslogger, syslogger,
+      	    #{
+      		config => #{ facility => local0 },
+      		formatter => {logger_formatter, #{single_line => true}}
+      	}}]}]
+    }.	
 
-This will add two syslogger instances to the Erlang logger that use different facilities.
-
-The same effect could have been achieved by using the logger API like this:
-
-    logger:add_handler(user_syslogger, syslogger, #{ facility => user }),
-    logger:add_handler(local0_syslogger, syslogger, #{ facility => local0 }).
+This will add two syslogger instances to the Erlang l
 
 Each syslogger handler can be configured using a map with these configuration options:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 syslogger
 =====
 
-A syslog backend for erlang logger.. This is a fork of the syslogger with update to the application configuration settings
+A syslog backend for erlang logger.
 
 Usage
 -----
@@ -11,7 +11,7 @@ in your rebar.config like this:
 
     {deps,
      [
-      { 'syslogger', "*", {git, "https://github.com/sadekoya/syslogger.git", {branch, "master"}}}
+      { 'syslogger', "*", {git, "git://github.com/garazdawi/syslogger", {branch, "master"}}}
      ]
     }.
 
@@ -55,7 +55,7 @@ facilities just add this to your sys.config.
       	}}]}]
     }.	
 
-This will add a syslogger instances to the Erlang l
+This will add a syslogger instance to the Erlang 
 
 Each syslogger handler can be configured using a map with these configuration options:
 


### PR DESCRIPTION
It appears the Readme section for setting syslog facility is outdated. I have modified the page with a working config setting. e.g. local0