### PR TITLE
Ignore the result of `make clean` as it might not be there yet.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ c_src/Makefile: c_src/configure
 	(cd c_src && ./configure --prefix=$(shell pwd)/priv ${CONFIGURE_FLAGS})
 
 clean_nif:
-	make -C c_src clean uninstall
+	- make -C c_src clean uninstall


### PR DESCRIPTION
Given that the `c_src/Makefile` is created as part of the build it will not exist yet when running `make clean` on a cleanly cloned repository.

This PR makes it ignore the result of the clean, so that it doesn't matter if your Jenkins pipeline is running `make clean` on a fresh copy of the lib for some ungodly reason. :)